### PR TITLE
chore(deps): bump fluid-lint-all to 1.0.5-dev

### DIFF
--- a/.fluidlintallrc.json
+++ b/.fluidlintallrc.json
@@ -2,13 +2,7 @@
     "eslint": {
         "js": {
             "includes": ["./.eleventy.js"]
-        },
-        "json": {
-            "excludes": ["./src/_data/assets.json"]
         }
-    },
-    "jsonlint": {
-        "excludes": ["./src/_data/assets.json"]
     },
     "markdownlint": {
         "excludes": ["./CHANGELOG.md"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8100,9 +8100,9 @@
             }
         },
         "fluid-lint-all": {
-            "version": "1.0.4-dev.20210129T151721Z.b9ddeaa.GH-12-1",
-            "resolved": "https://registry.npmjs.org/fluid-lint-all/-/fluid-lint-all-1.0.4-dev.20210129T151721Z.b9ddeaa.GH-12-1.tgz",
-            "integrity": "sha512-OWgZhHHO93vDEk9eBG2q/gp0lx10L9EDxYmEu+isp8BRL6f72jcOgsbKypo77mQD0FYtaC9tG5rFyLZtmDuq2w==",
+            "version": "1.0.5-dev.20210201T163615Z.cff0a11.GH-3",
+            "resolved": "https://registry.npmjs.org/fluid-lint-all/-/fluid-lint-all-1.0.5-dev.20210201T163615Z.cff0a11.GH-3.tgz",
+            "integrity": "sha512-sCLl1tCNbPGQ0NMyEFLGNOHXIYfSvY+pAjRIKdVlY0qVUvbM2okFzjqhOprEpKYXEBVmtmY2BGsKrN6bhyXF2Q==",
             "dev": true,
             "requires": {
                 "@textlint/markdown-to-ast": "6.2.6",
@@ -8117,6 +8117,7 @@
                 "lintspaces": "0.7.0",
                 "markdownlint": "0.22.0",
                 "markdownlint-config-fluid": "0.1.2",
+                "minimatch": "3.0.4",
                 "minimist": "1.2.5",
                 "stylelint": "13.8.0",
                 "stylelint-config-fluid": "0.1.0"
@@ -11577,9 +11578,9 @@
             "dev": true
         },
         "micromark": {
-            "version": "2.11.2",
-            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.2.tgz",
-            "integrity": "sha512-IXuP76p2uj8uMg4FQc1cRE7lPCLsfAXuEfdjtdO55VRiFO1asrCSQ5g43NmPqFtRwzEnEhafRVzn2jg0UiKArQ==",
+            "version": "2.11.3",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.3.tgz",
+            "integrity": "sha512-oph5YYkVqR2U9OtWBcXYysZMtrdIvi8dfSeyEdr1wFr3Bk6YwI6THosX2AzKnhdps7mVUbXiqhmosu9DcA+xlQ==",
             "dev": true,
             "requires": {
                 "debug": "^4.0.0",
@@ -18268,9 +18269,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
-                    "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz",
+                    "integrity": "sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@commitlint/config-conventional": "11.0.0",
         "cross-env": "7.0.3",
         "debug": "4.3.1",
-        "fluid-lint-all": "1.0.4-dev.20210129T151721Z.b9ddeaa.GH-12-1",
+        "fluid-lint-all": "1.0.5-dev.20210201T163615Z.cff0a11.GH-3",
         "html-minifier": "4.0.0",
         "husky": "4.3.7",
         "image-size": "0.9.3",


### PR DESCRIPTION
No need to exclude .gitignore'd files from .fluidlintallrc.json anymore.