### PR TITLE
fix: remove duplicate uioScripts call (resolves #236)

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -14,7 +14,6 @@
         {% include "partials/global/icons.njk" %}
         <link rel="manifest" href="/manifest.webmanifest">
 
-        {% uioScripts %}
         {% include "partials/global/scripts.njk" %}
     </head>
     <body class="{{ bodyClass if bodyClass else "page" }}">


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Removes duplicate instance of `{% uioScripts %}` shortcode from `base.njk`.

## Steps to test

1. Start the site in development mode: `npm run start`
2. Inspect the document.

**Expected behavior:** UIO scripts are only loaded once.

## Additional information

Not applicable.

## Related issues

Resolves #236.