### PR TITLE
feat: add localized 404 pages (resolves #164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ following changes need to be made:
    Markdown files are processed with the Liquid template language. If for some reason one decides to modify this to use
    Nunjucks or another template language, the permalink syntax in all post archive pages will need to be modified to use
    the chosen template language.)
+5. Create a localized version of the 404 page, following the example of [`src/404.fr-CA.md`](src/404.fr-CA.md).
+   (Note: as per Eleventy's [default configuration](https://www.11ty.dev/docs/config/#default-template-engine-for-markdown-files),
+   Markdown files are processed with the Liquid template language. If for some reason one decides to modify this to use
+   Nunjucks or another template language, the permalink syntax in all post archive pages will need to be modified to use
+   the chosen template language.)
+6. To ensure that the 404 page is displayed in the appropriate language, verify that a redirect block has been added to
+   the [netlify.toml](netlify.toml) file for each language following the examples. This feature is described in
+   Netlify's [redirects documentation](https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling).
 
 For more information about how Netlify CMS works with internationalized content, see the [internationalization support documentation](https://www.netlifycms.org/docs/beta-features/#i18n-support).
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,15 @@
   publish = "dist"
   autoLaunch = false
   framework = "#custom"
+
+
+[[redirects]]
+  from = "/fr/*"
+  to = "/fr/404.html"
+  status = 404
+
+# English (or default language) 404 page must come last.
+[[redirects]]
+  from = "/*"
+  to = "/404.html"
+  status = 404

--- a/src/404.en-CA.md
+++ b/src/404.en-CA.md
@@ -1,0 +1,8 @@
+---
+layout: layouts/base
+title: Page Not Found
+lang: en-CA
+translationKey: 404
+permalink: "{% if lang != config.defaultLanguage %}/{{ config.languages[lang].slug }}{% endif %}/404.html"
+---
+The page you were looking for does not exist. Go back to the [home page?](/)

--- a/src/404.fr-CA.md
+++ b/src/404.fr-CA.md
@@ -5,4 +5,4 @@ lang: fr-CA
 translationKey: 404
 permalink: "{% if lang != config.defaultLanguage %}/{{ config.languages[lang].slug }}{% endif %}/404.html"
 ---
-La page que vous recherchez n'existe pas. Retournez à la [page d'accueil?](/)
+La page que vous recherchez n'existe pas. Retournez à la [page d'accueil?](/fr/)

--- a/src/404.fr-CA.md
+++ b/src/404.fr-CA.md
@@ -1,0 +1,8 @@
+---
+layout: layouts/base
+title: Page non trouvée
+lang: fr-CA
+translationKey: 404
+permalink: "{% if lang != config.defaultLanguage %}/{{ config.languages[lang].slug }}{% endif %}/404.html"
+---
+La page que vous recherchez n'existe pas. Retournez à la [page d'accueil?](/)

--- a/src/404.md
+++ b/src/404.md
@@ -1,6 +1,0 @@
----
-layout: layouts/base
-title: Page Not Found
-permalink: 404.html
----
-The page you were looking for does not exist. Go back to the [home page?](/)

--- a/src/_includes/partials/components/navigation.njk
+++ b/src/_includes/partials/components/navigation.njk
@@ -7,11 +7,14 @@
                     </li>
                     {% endfor %}
                     {% for item in collections.all %}
-                        {# Find an item with a translation key which matches the current page's translation key but is not the same language. #}
-                        {% if item.data.translationKey == translationKey and item.data.lang !== lang %}
-                        <li lang="{{ item.data.lang }}">
-                            <a href="{{ item.url }}">{{ config.languages[item.data.lang].name }}</a>
-                        </li>
+                        {% if translationKey == 404 and item.data.translationKey == 'index' and item.data.lang !== lang %}
+                            <li lang="{{ item.data.lang }}">
+                                <a href="{{ item.url }}">{{ config.languages[item.data.lang].name }}</a>
+                            </li>                            
+                        {% elif translationKey !== 404 and item.data.translationKey == translationKey and item.data.lang !== lang %}
+                            <li lang="{{ item.data.lang }}">
+                                <a href="{{ item.url }}">{{ config.languages[item.data.lang].name }}</a>
+                            </li>
                         {% endif %}
                     {% endfor %}
                 </ul>

--- a/src/_includes/partials/components/navigation.njk
+++ b/src/_includes/partials/components/navigation.njk
@@ -7,11 +7,10 @@
                     </li>
                     {% endfor %}
                     {% for item in collections.all %}
-{% if item.data.lang !== lang and item.data.translationKey == ('index' if translationKey == 404 else translationKey) %}
+                        {% if item.data.lang !== lang and item.data.translationKey == ('index' if translationKey == 404 else translationKey) %}
                             <li lang="{{ item.data.lang }}">
                                 <a href="{{ item.url }}">{{ config.languages[item.data.lang].name }}</a>
                             </li>
-                        {% endif %}
                         {% endif %}
                     {% endfor %}
                 </ul>

--- a/src/_includes/partials/components/navigation.njk
+++ b/src/_includes/partials/components/navigation.njk
@@ -7,14 +7,11 @@
                     </li>
                     {% endfor %}
                     {% for item in collections.all %}
-                        {% if translationKey == 404 and item.data.translationKey == 'index' and item.data.lang !== lang %}
-                            <li lang="{{ item.data.lang }}">
-                                <a href="{{ item.url }}">{{ config.languages[item.data.lang].name }}</a>
-                            </li>                            
-                        {% elif translationKey !== 404 and item.data.translationKey == translationKey and item.data.lang !== lang %}
+{% if item.data.lang !== lang and item.data.translationKey == ('index' if translationKey == 404 else translationKey) %}
                             <li lang="{{ item.data.lang }}">
                                 <a href="{{ item.url }}">{{ config.languages[item.data.lang].name }}</a>
                             </li>
+                        {% endif %}
                         {% endif %}
                     {% endfor %}
                 </ul>


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds support for localized 404 error pages on Netlify.

## Steps to test

1. Visit a nonexistent page on the deploy preview: https://deploy-preview-238--trivet.netlify.app/missing-page
2. Visit an nonexistent page on the deploy preview with the French URL prefix: https://deploy-preview-238--trivet.netlify.app/fr/page-disparu

**Expected behavior:** For the base (English) URL, the 404 page should be in English. For the prefixed (French) URL, the 404 page should be in French. In both cases, the links in the navigation to the alternate language should direct visitors to the home page in that language.

## Additional information

Uses [this Netlify feature](https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling) in the [netlify.toml](https://github.com/greatislander/trivet/blob/ce58133b15cfa67b06285788d1ae625a646a29b4/netlify.toml#L14-L23) file.

## Related issues

Resolves #164.