### PR TITLE
feat: generate sitemap.xml (resolves #243)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,15 @@
   autoLaunch = false
   framework = "#custom"
 
+[[headers]]
+  for = "/admin/*"
+  [headers.values]
+    X-Robots-Tag = "noindex"
+
+[[headers]]
+  for = "**/404.html"
+  [headers.values]
+    X-Robots-Tag = "noindex"
 
 [[redirects]]
   from = "/fr/*"

--- a/src/404.en-CA.md
+++ b/src/404.en-CA.md
@@ -4,5 +4,6 @@ title: Page Not Found
 lang: en-CA
 translationKey: 404
 permalink: "{% if lang != config.defaultLanguage %}/{{ config.languages[lang].slug }}{% endif %}/404.html"
+eleventyExcludeFromCollections: true
 ---
 The page you were looking for does not exist. Go back to the [home page?](/)

--- a/src/404.fr-CA.md
+++ b/src/404.fr-CA.md
@@ -4,5 +4,6 @@ title: Page non trouvée
 lang: fr-CA
 translationKey: 404
 permalink: "{% if lang != config.defaultLanguage %}/{{ config.languages[lang].slug }}{% endif %}/404.html"
+eleventyExcludeFromCollections: true
 ---
 La page que vous recherchez n'existe pas. Retournez à la [page d'accueil?](/fr/)

--- a/src/admin/admin.njk
+++ b/src/admin/admin.njk
@@ -1,5 +1,6 @@
 ---
 permalink: '/admin/index.html'
+eleventyExcludeFromCollections: true
 ---
 <!doctype html>
 <html>

--- a/src/admin/config.njk
+++ b/src/admin/config.njk
@@ -1,5 +1,6 @@
 ---
 permalink: /admin/config.yml
+eleventyExcludeFromCollections: true
 ---
 backend:
   name: git-gateway
@@ -67,4 +68,3 @@ collections:
           - { label: "Author Name", name: authorName, widget: string, i18n: true }
           - { label: "Author Email", name: authorEmail, widget: string, i18n: duplicate }
           - { label: "Author Website", name: authorWebsite, widget: string, i18n: duplicate }
-          

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -4,6 +4,7 @@ pagination:
   size: 1
   alias: language
 permalink: "{% if language !== config.defaultLanguage %}/{{ config.languages[language].slug }}{% endif %}/feed.xml"
+eleventyExcludeFromCollections: true
 ---
 {% set collection = "postFeed_" + language %}
 <?xml version="1.0" encoding="utf-8"?>

--- a/src/robots.njk
+++ b/src/robots.njk
@@ -1,0 +1,9 @@
+---
+permalink: /robots.txt
+eleventyExcludeFromCollections: true
+---
+Sitemap: {{ site[config.defaultLanguage].url }}/sitemap.xml
+
+User-Agent: *
+Disallow: /404.html
+Disallow: /admin/

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -1,0 +1,20 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    {% for page in collections.all %}
+        {% if page.url -%}
+        <url>
+            <loc>{{ site[config.defaultLanguage].url }}{{ page.url | url }}</loc>
+            <lastmod>{{ page.date.toISOString() }}</lastmod>
+            {% for relatedPage in collections.all -%}
+                {% if page.data.translationKey and page.data.translationKey ===relatedPage.data.translationKey %}
+                <xhtml:link rel="alternate" hreflang="{{ relatedPage.data.lang}}" href="{{ site[config.defaultLanguage].url }}{{ relatedPage.url }}"/>
+                {%- endif %}
+            {%- endfor %}
+        </url>
+        {%- endif %}
+    {% endfor %}
+</urlset>

--- a/src/webmanifest.njk
+++ b/src/webmanifest.njk
@@ -1,5 +1,6 @@
 ---
 permalink: /manifest.webmanifest
+eleventyExcludeFromCollections: true
 ---
 {
   "icons": [


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

<!-- A description of the pull request -->

## Steps to test

1. Perform a build: `npm start` or `npm run build`

**Expected behavior:**  The sitemap.xml and robots.txt files should be generated at the root of the site.

## Additional information

This PR also removes the `/admin/` and `404.html` pages from indexing.

## Related issues

Resolves #243 
