### PR TITLE
fix: resolve sitemap parsing error in Chrome

### DIFF
--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -3,7 +3,7 @@ permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for page in collections.all %}
     {%- if page.url and page.data.locale == "en-CA" -%}
     <url>
@@ -11,7 +11,7 @@ eleventyExcludeFromCollections: true
         <lastmod>{{ page.date.toISOString() }}</lastmod>
         {% set links = page.url | locale_links %}
         {%- for link in links -%}
-        <xhtml:link rel="alternate" hreflang="{{ link.lang }}" href="{{ site[defaultLanguage].url }}{{ link.url }}"/>
+        <link rel="alternate" hreflang="{{ link.lang }}" href="{{ site[defaultLanguage].url }}{{ link.url }}"/>
         {%- endfor %}
     </url>
     {% endif -%}


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

In testing these updates with the IDRC site, @chosww noticed that the sitemap XML file was not loading properly in Chromium browsers.

Compare this: https://trivet.netlify.app/sitemap.xml

To this: https://sitemaps.org/sitemap.xml

In testing with Daniel we found that removing the XHTML schema resolved the issue.

## Steps to test

1. Load the sitemap.xml from this PR's deploy preview in a Chromium browser.

**Expected behavioor:** The XML tree renders properly.

## Additional information

https://www.sitemaps.org/protocol.html

## Related issues

https://github.com/inclusive-design/idrc/pull/665#issuecomment-1671928748