### PR TITLE
fix: move generatePermalink out of eleventyComputed

### DIFF
--- a/src/collections/pages/en-CA/posts.md
+++ b/src/collections/pages/en-CA/posts.md
@@ -6,5 +6,4 @@ pagination:
   data: collections.posts_en-CA
   size: 10
   alias: posts
-permalink: "{% if locale != defaultLanguage %}/{{ supportedLanguages[locale].slug }}{% endif %}/{% _ locale, 'posts' %}/{% if pagination.pageNumber > 0 %}{% _ locale, 'page' %}/{{ pagination.pageNumber + 1 }}/{% endif %}"
 ---

--- a/src/collections/pages/fr-CA/posts.md
+++ b/src/collections/pages/fr-CA/posts.md
@@ -6,5 +6,4 @@ pagination:
   data: collections.posts_fr-CA
   size: 10
   alias: posts
-permalink: "{% if locale != defaultLanguage %}/{{ supportedLanguages[locale].slug }}{% endif %}/{% _ locale, 'posts' %}/{% if pagination.pageNumber > 0 %}{% _ locale, 'page' %}/{{ pagination.pageNumber + 1 }}/{% endif %}"
 ---

--- a/src/collections/pages/pages.11tydata.js
+++ b/src/collections/pages/pages.11tydata.js
@@ -4,6 +4,11 @@ const i18n = require("eleventy-plugin-i18n-gettext");
 const { generatePermalink } = require("eleventy-plugin-fluid");
 
 module.exports = {
+    /* Build a permalink using the page title and language. */
+    permalink: data => {
+        const locale = data.locale;
+        return generatePermalink(data, "pages", false, i18n._(locale, "page"));
+    },
     eleventyComputed: {
         langDir: data => data.supportedLanguages[data.locale].dir,
         eleventyNavigation: data => {
@@ -18,11 +23,6 @@ module.exports = {
                 };
             }
             return false;
-        },
-        /* Build a permalink using the page title and language. */
-        permalink: data => {
-            const locale = data.locale;
-            return generatePermalink(data, "pages", false, i18n._(locale, "page"));
         }
     }
 };

--- a/src/collections/posts/en-CA/post-1.md
+++ b/src/collections/posts/en-CA/post-1.md
@@ -1,0 +1,7 @@
+---
+title: Post 1
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-10.md
+++ b/src/collections/posts/en-CA/post-10.md
@@ -1,0 +1,7 @@
+---
+title: Post 10
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-10.md
+++ b/src/collections/posts/en-CA/post-10.md
@@ -1,6 +1,6 @@
 ---
 title: Post 10
-date: 2020-06-22
+date: 2020-07-01
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-11.md
+++ b/src/collections/posts/en-CA/post-11.md
@@ -1,6 +1,6 @@
 ---
 title: Post 11
-date: 2020-06-22
+date: 2020-07-02
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-11.md
+++ b/src/collections/posts/en-CA/post-11.md
@@ -1,0 +1,7 @@
+---
+title: Post 11
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-2.md
+++ b/src/collections/posts/en-CA/post-2.md
@@ -1,6 +1,6 @@
 ---
 title: Post 2
-date: 2020-06-22
+date: 2020-06-23
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-2.md
+++ b/src/collections/posts/en-CA/post-2.md
@@ -1,0 +1,7 @@
+---
+title: Post 2
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-3.md
+++ b/src/collections/posts/en-CA/post-3.md
@@ -1,0 +1,7 @@
+---
+title: Post 3
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-3.md
+++ b/src/collections/posts/en-CA/post-3.md
@@ -1,6 +1,6 @@
 ---
 title: Post 3
-date: 2020-06-22
+date: 2020-06-24
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-4.md
+++ b/src/collections/posts/en-CA/post-4.md
@@ -1,0 +1,7 @@
+---
+title: Post 4
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-4.md
+++ b/src/collections/posts/en-CA/post-4.md
@@ -1,6 +1,6 @@
 ---
 title: Post 4
-date: 2020-06-22
+date: 2020-06-25
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-5.md
+++ b/src/collections/posts/en-CA/post-5.md
@@ -1,6 +1,6 @@
 ---
 title: Post 5
-date: 2020-06-22
+date: 2020-06-26
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-5.md
+++ b/src/collections/posts/en-CA/post-5.md
@@ -1,0 +1,7 @@
+---
+title: Post 5
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-6.md
+++ b/src/collections/posts/en-CA/post-6.md
@@ -1,0 +1,7 @@
+---
+title: Post 6
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-6.md
+++ b/src/collections/posts/en-CA/post-6.md
@@ -1,6 +1,6 @@
 ---
 title: Post 6
-date: 2020-06-22
+date: 2020-06-27
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-7.md
+++ b/src/collections/posts/en-CA/post-7.md
@@ -1,6 +1,6 @@
 ---
 title: Post 7
-date: 2020-06-22
+date: 2020-06-28
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-7.md
+++ b/src/collections/posts/en-CA/post-7.md
@@ -1,5 +1,5 @@
 ---
-title: My Post
+title: Post 7
 date: 2020-06-22
 excerpt: This is a short description of the post.
 author: Fluid Project

--- a/src/collections/posts/en-CA/post-8.md
+++ b/src/collections/posts/en-CA/post-8.md
@@ -1,0 +1,7 @@
+---
+title: Post 8
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/en-CA/post-8.md
+++ b/src/collections/posts/en-CA/post-8.md
@@ -1,6 +1,6 @@
 ---
 title: Post 8
-date: 2020-06-22
+date: 2020-06-29
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-9.md
+++ b/src/collections/posts/en-CA/post-9.md
@@ -1,6 +1,6 @@
 ---
 title: Post 9
-date: 2020-06-22
+date: 2020-06-30
 excerpt: This is a short description of the post.
 author: Fluid Project
 ---

--- a/src/collections/posts/en-CA/post-9.md
+++ b/src/collections/posts/en-CA/post-9.md
@@ -1,0 +1,7 @@
+---
+title: Post 9
+date: 2020-06-22
+excerpt: This is a short description of the post.
+author: Fluid Project
+---
+You can write content for your post in [Markdown](https://www.11ty.dev/docs/languages/markdown/) format.

--- a/src/collections/posts/fr-CA/post-1.md
+++ b/src/collections/posts/fr-CA/post-1.md
@@ -1,0 +1,7 @@
+---
+title: Article 1
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-10.md
+++ b/src/collections/posts/fr-CA/post-10.md
@@ -1,0 +1,7 @@
+---
+title: Article 10
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-10.md
+++ b/src/collections/posts/fr-CA/post-10.md
@@ -1,6 +1,6 @@
 ---
 title: Article 10
-date: 2020-06-22
+date: 2020-07-01
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-11.md
+++ b/src/collections/posts/fr-CA/post-11.md
@@ -1,6 +1,6 @@
 ---
 title: Article 11
-date: 2020-06-22
+date: 2020-07-02
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-11.md
+++ b/src/collections/posts/fr-CA/post-11.md
@@ -1,0 +1,7 @@
+---
+title: Article 11
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-2.md
+++ b/src/collections/posts/fr-CA/post-2.md
@@ -1,6 +1,6 @@
 ---
 title: Article 2
-date: 2020-06-22
+date: 2020-06-23
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-2.md
+++ b/src/collections/posts/fr-CA/post-2.md
@@ -1,0 +1,7 @@
+---
+title: Article 2
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-3.md
+++ b/src/collections/posts/fr-CA/post-3.md
@@ -1,0 +1,7 @@
+---
+title: Article 3
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-3.md
+++ b/src/collections/posts/fr-CA/post-3.md
@@ -1,6 +1,6 @@
 ---
 title: Article 3
-date: 2020-06-22
+date: 2020-06-24
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-4.md
+++ b/src/collections/posts/fr-CA/post-4.md
@@ -1,6 +1,6 @@
 ---
 title: Article 4
-date: 2020-06-22
+date: 2020-06-25
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-4.md
+++ b/src/collections/posts/fr-CA/post-4.md
@@ -1,5 +1,5 @@
 ---
-title: Mon article
+title: Article 4
 date: 2020-06-22
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid

--- a/src/collections/posts/fr-CA/post-5.md
+++ b/src/collections/posts/fr-CA/post-5.md
@@ -1,6 +1,6 @@
 ---
 title: Article 5
-date: 2020-06-22
+date: 2020-06-26
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-5.md
+++ b/src/collections/posts/fr-CA/post-5.md
@@ -1,0 +1,7 @@
+---
+title: Article 5
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-6.md
+++ b/src/collections/posts/fr-CA/post-6.md
@@ -1,0 +1,7 @@
+---
+title: Article 6
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-6.md
+++ b/src/collections/posts/fr-CA/post-6.md
@@ -1,6 +1,6 @@
 ---
 title: Article 6
-date: 2020-06-22
+date: 2020-06-27
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-7.md
+++ b/src/collections/posts/fr-CA/post-7.md
@@ -1,6 +1,6 @@
 ---
 title: Article 7
-date: 2020-06-22
+date: 2020-06-28
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-7.md
+++ b/src/collections/posts/fr-CA/post-7.md
@@ -1,0 +1,7 @@
+---
+title: Article 7
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-8.md
+++ b/src/collections/posts/fr-CA/post-8.md
@@ -1,0 +1,7 @@
+---
+title: Article 8
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/fr-CA/post-8.md
+++ b/src/collections/posts/fr-CA/post-8.md
@@ -1,6 +1,6 @@
 ---
 title: Article 8
-date: 2020-06-22
+date: 2020-06-29
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-9.md
+++ b/src/collections/posts/fr-CA/post-9.md
@@ -1,6 +1,6 @@
 ---
 title: Article 9
-date: 2020-06-22
+date: 2020-06-30
 description: "Ceci est une brève description de l'article. "
 author: Projet Fluid
 ---

--- a/src/collections/posts/fr-CA/post-9.md
+++ b/src/collections/posts/fr-CA/post-9.md
@@ -1,0 +1,7 @@
+---
+title: Article 9
+date: 2020-06-22
+description: "Ceci est une brève description de l'article. "
+author: Projet Fluid
+---
+Vous pouvez rédiger le contenu de votre article au format [Markdown](https://www.11ty.dev/docs/languages/markdown/).

--- a/src/collections/posts/posts.11tydata.js
+++ b/src/collections/posts/posts.11tydata.js
@@ -5,11 +5,11 @@ const { generatePermalink } = require("eleventy-plugin-fluid");
 
 module.exports = {
     layout: "layouts/post",
+    permalink: data => {
+        const locale = data.locale;
+        return generatePermalink(data, "posts", i18n._(locale, "posts"));
+    },
     eleventyComputed: {
-        langDir: data => data.supportedLanguages[data.locale].dir,
-        permalink: data => {
-            const locale = data.locale;
-            return generatePermalink(data, "posts", i18n._(locale, "posts"));
-        }
+        langDir: data => data.supportedLanguages[data.locale].dir
     }
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

See https://github.com/fluid-project/eleventy-plugin-fluid/pull/201.

## Steps to test

1. Run `npm start`
2. Test pagination.

**Expected behaviour:** Post index pages are generated and can be navigated using the pagination component.

## Additional information

Not applicable.

## Related issues

Not applicable.
