### PR TITLE
chore(deps-dev): prevent updates to Stylelint >= 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,15 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check for updates once a month
     schedule:
       interval: "monthly"
     allow:
-      # Allow direct updates only (for packages named in package.json)
       - dependency-type: "direct"
-  # Enable version updates for npm
+    ignore:
+      - dependency-name: "stylelint"
+        versions: ["^15"]
   - package-ecosystem: github-actions
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check for updates once a month
     schedule:
       interval: "monthly"


### PR DESCRIPTION
`stylelint-config-fluid` is not compatible with stylelint >= 15 (see: https://github.com/accessibility-exchange/platform/issues/1576).

This PR prevents Dependabot from suggesting updates beyond stylelint 14.* until a new version of `stylelint-config-fluid` is available.

Additionally, React must be locked to version 16 for Decap CMS compatibility.