### PR TITLE
fix: simplify YAML lint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         "fluid",
         "plugin:yml/standard"
     ],
-    ignorePatterns: ["_site/", "src/_locales/messages.js", "!.*.cjs", "!.*.js"],
+    ignorePatterns: ["_site/", "src/_locales/messages.js", "!.*.cjs", "!.*.js", "!.github/"],
     env: {
         amd: true,
         browser: true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint:css": "stylelint \"**/*.css\"",
         "lint:js": "eslint \"**/*.js\"",
         "lint:markdown": "markdownlint-cli2 \"**/*.md\"",
-        "lint:yml": "eslint --no-error-on-unmatched-pattern \".github/**/*.yml\" \"**/*.yml\"",
+        "lint:yml": "eslint \"**/*.yml\"",
         "start": "npm-run-all -l clean -p start:*",
         "start:eleventy": "run-p dev cms",
         "prepare": "husky install"


### PR DESCRIPTION
To test, modify any *.yml files in a way that will cause them to fail linting and ensure that the `lint:yml` command catches the failure.